### PR TITLE
Bugfix/migrations-fix

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
 ---
-- plugins:
-  - bandit:
-      enabled: true
+version: "2"
+plugins:
+  bandit:
+    enabled: true

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,3 +13,4 @@ applications:
     env:
       SECRET_KEY: ((SECRET_KEY))
       DISABLE_COLLECTSTATIC: 1
+      DJANGO_SETTINGS_MODULE: idemia.settings

--- a/migrations.py
+++ b/migrations.py
@@ -3,9 +3,11 @@ migrations.py implements the 'Migrate Frequently' section of
 https://docs.huihoo.com/cloudfoundry/documentation/devguide/services/migrate-db.html
 """
 import logging
+import os
 from cfenv import AppEnv
 from django.core.management import execute_from_command_line
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "idemia.settings")
 ENV = AppEnv()
 
 


### PR DESCRIPTION
Set DJANGO_SETTINGS_MODULE to idemia.settings even if it is not found in
the environment to prevent script failure due to not being able to
identify django settings.