### PR TITLE
Add read_only to record_status in serializer used to generate docs

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -23,3 +23,4 @@ class EnrollmentRecordCreateSerializer(EnrollmentRecordSerializer):
     # added fields from request object. Not stored in database
     firstName = serializers.CharField()
     lastName = serializers.CharField()
+    record_status = serializers.CharField(read_only=True)


### PR DESCRIPTION
when generating docs, the record_status should not appear as a
value in the request body. Setting it to read only in the
doc serializer fixes this