### PR TITLE
Correct enrollment record first/last name in docs. fixes #51

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -21,6 +21,6 @@ class EnrollmentRecordCreateSerializer(EnrollmentRecordSerializer):
     """ Serializer for EnrollmentRecord objects when they are created """
 
     # added fields from request object. Not stored in database
-    firstName = serializers.CharField()
-    lastName = serializers.CharField()
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
     record_status = serializers.CharField(read_only=True)


### PR DESCRIPTION
First and last name variables are now set correctly in the serializer used for generating swagger documentation.